### PR TITLE
Add retro menu and static scenario prototype

### DIFF
--- a/menu.css
+++ b/menu.css
@@ -1,0 +1,73 @@
+:root {
+  --bg-pattern: radial-gradient(circle at 10% 20%, rgba(255, 0, 102, 0.35) 0 12%, transparent 12% 100%),
+    radial-gradient(circle at 80% 10%, rgba(0, 230, 255, 0.25) 0 15%, transparent 15% 100%),
+    radial-gradient(circle at 50% 80%, rgba(255, 221, 0, 0.2) 0 20%, transparent 20% 100%);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: 'Press Start 2P', 'Courier New', Courier, monospace;
+  color: #fff5f5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  background-color: #050813;
+  background-image: linear-gradient(135deg, rgba(12, 17, 46, 0.9), rgba(22, 8, 64, 0.9)), var(--bg-pattern),
+    url('https://images.unsplash.com/photo-1582719478248-4b8b5b8b5b8b?auto=format&fit=crop&w=1600&q=80');
+  background-size: cover;
+  background-position: center;
+}
+
+.menu-panel {
+  background: rgba(5, 8, 19, 0.85);
+  padding: 3rem 4rem;
+  border-radius: 18px;
+  border: 3px solid rgba(255, 255, 255, 0.3);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.65);
+}
+
+.menu-panel h1 {
+  font-size: 2.5rem;
+  margin-bottom: 2.5rem;
+  letter-spacing: 0.2rem;
+  text-shadow: 0 0 12px rgba(255, 73, 246, 0.7);
+}
+
+.play-button {
+  font: inherit;
+  padding: 1.2rem 2.4rem;
+  border-radius: 12px;
+  border: 3px solid #ff4df6;
+  background: linear-gradient(135deg, #ff4df6, #ffb347);
+  color: #050813;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  text-transform: uppercase;
+}
+
+.play-button:hover,
+.play-button:focus {
+  transform: translateY(-4px);
+  box-shadow: 0 12px 22px rgba(255, 77, 246, 0.45);
+}
+
+@media (max-width: 600px) {
+  .menu-panel {
+    width: min(90%, 22rem);
+    padding: 2.5rem 2rem;
+  }
+
+  .menu-panel h1 {
+    font-size: 1.8rem;
+  }
+
+  .play-button {
+    width: 100%;
+  }
+}

--- a/menu.html
+++ b/menu.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="it">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Retro Arcade - Menu</title>
+    <link rel="stylesheet" href="menu.css" />
+  </head>
+  <body>
+    <div class="menu-panel">
+      <h1>Retro Arcade</h1>
+      <button id="playButton" class="play-button">Play</button>
+    </div>
+    <script src="menu.js"></script>
+  </body>
+</html>

--- a/menu.js
+++ b/menu.js
@@ -1,0 +1,7 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const playButton = document.getElementById('playButton');
+
+  playButton.addEventListener('click', () => {
+    window.location.href = 'scenario.html';
+  });
+});

--- a/scenario.css
+++ b/scenario.css
@@ -1,0 +1,66 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: url('https://images.unsplash.com/photo-1618005198919-d3d4b5a92eee?auto=format&fit=crop&w=1600&q=80')
+      center/cover fixed,
+    linear-gradient(#6fb7ff, #1f2545);
+  font-family: 'Press Start 2P', 'Courier New', Courier, monospace;
+  color: #fff;
+}
+
+.game-wrapper {
+  position: relative;
+  max-width: 960px;
+  width: 100%;
+  padding: 1.5rem;
+  background: rgba(10, 16, 33, 0.7);
+  border: 3px solid rgba(255, 255, 255, 0.2);
+  border-radius: 20px;
+  box-shadow: 0 24px 45px rgba(0, 0, 0, 0.6);
+}
+
+.hud {
+  position: absolute;
+  top: 0.5rem;
+  left: 1.5rem;
+  z-index: 2;
+}
+
+.lives .heart {
+  display: inline-block;
+  font-size: 1.4rem;
+  color: #ff5d73;
+  margin-right: 0.2rem;
+  text-shadow: 0 0 6px rgba(255, 93, 115, 0.7);
+}
+
+.game-area {
+  position: relative;
+  overflow: hidden;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  border-radius: 12px;
+  border: 2px solid rgba(255, 255, 255, 0.15);
+  background: linear-gradient(#9ce5ff, #6fb7ff);
+}
+
+@media (max-width: 768px) {
+  .game-wrapper {
+    margin: 1rem;
+    padding: 1rem;
+  }
+
+  .hud {
+    left: 1rem;
+  }
+}

--- a/scenario.html
+++ b/scenario.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="it">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Retro Arcade - Scenario</title>
+    <link rel="stylesheet" href="scenario.css" />
+  </head>
+  <body>
+    <div class="game-wrapper">
+      <header class="hud">
+        <div class="lives" aria-label="Vite">
+          <span class="heart" aria-hidden="true">❤</span>
+          <span class="heart" aria-hidden="true">❤</span>
+          <span class="heart" aria-hidden="true">❤</span>
+        </div>
+      </header>
+      <main class="game-area">
+        <canvas id="gameCanvas" width="960" height="540" aria-label="Scenario di gioco"></canvas>
+      </main>
+    </div>
+    <script src="scenario.js"></script>
+  </body>
+</html>

--- a/scenario.js
+++ b/scenario.js
@@ -1,0 +1,200 @@
+const canvas = document.getElementById('gameCanvas');
+const ctx = canvas.getContext('2d');
+
+const tileSize = 60;
+const map = [
+  [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+  [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+  [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+  [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+  [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+  [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+  [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+  [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+  [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+  [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+];
+
+// add floating platforms
+map[6][10] = 1;
+map[6][11] = 1;
+map[6][12] = 1;
+map[3][4] = 1;
+map[3][5] = 1;
+map[3][6] = 1;
+
+const player = {
+  width: 34,
+  height: 48,
+  x: tileSize * 1.5,
+  y: canvas.height - tileSize * 2 - 48,
+  vx: 0,
+  vy: 0,
+  speed: 0.75,
+  maxSpeed: 4.2,
+  jumpForce: -12,
+  onGround: false
+};
+
+const pressedKeys = new Set();
+
+function isSolidTile(row, col) {
+  if (row < 0 || row >= map.length) return false;
+  if (col < 0 || col >= map[row].length) return false;
+  return map[row][col] === 1;
+}
+
+function checkCollision(x, y, width, height) {
+  const left = Math.floor(x / tileSize);
+  const right = Math.floor((x + width - 1) / tileSize);
+  const top = Math.floor(y / tileSize);
+  const bottom = Math.floor((y + height - 1) / tileSize);
+
+  for (let row = top; row <= bottom; row += 1) {
+    for (let col = left; col <= right; col += 1) {
+      if (isSolidTile(row, col)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function updatePlayer() {
+  const movingLeft = pressedKeys.has('ArrowLeft') || pressedKeys.has('KeyA');
+  const movingRight = pressedKeys.has('ArrowRight') || pressedKeys.has('KeyD');
+
+  if (movingLeft && !movingRight) {
+    player.vx -= player.speed;
+  } else if (movingRight && !movingLeft) {
+    player.vx += player.speed;
+  } else {
+    player.vx *= 0.82;
+    if (Math.abs(player.vx) < 0.05) player.vx = 0;
+  }
+
+  player.vx = Math.max(Math.min(player.vx, player.maxSpeed), -player.maxSpeed);
+
+  player.vy += 0.65; // gravity
+  if (player.vy > 14) player.vy = 14;
+
+  let nextX = player.x + player.vx;
+  let nextY = player.y + player.vy;
+
+  if (player.vx > 0) {
+    if (checkCollision(nextX, player.y, player.width, player.height)) {
+      nextX = Math.floor((player.x + player.width + player.vx) / tileSize) * tileSize - player.width - 0.01;
+      player.vx = 0;
+    }
+  } else if (player.vx < 0) {
+    if (checkCollision(nextX, player.y, player.width, player.height)) {
+      nextX = Math.floor(player.x / tileSize) * tileSize + 0.01;
+      player.vx = 0;
+    }
+  }
+
+  player.onGround = false;
+  if (player.vy > 0) {
+    if (checkCollision(nextX, nextY, player.width, player.height)) {
+      nextY = Math.floor((player.y + player.height + player.vy) / tileSize) * tileSize - player.height - 0.01;
+      player.vy = 0;
+      player.onGround = true;
+    }
+  } else if (player.vy < 0) {
+    if (checkCollision(nextX, nextY, player.width, player.height)) {
+      nextY = Math.floor(player.y / tileSize) * tileSize + 0.01;
+      player.vy = 0;
+    }
+  }
+
+  player.x = Math.max(0, Math.min(nextX, canvas.width - player.width));
+  player.y = Math.min(nextY, canvas.height - player.height);
+}
+
+function drawBackground() {
+  ctx.fillStyle = '#9ce5ff';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  // simple mountains
+  ctx.fillStyle = '#5ca1c4';
+  ctx.beginPath();
+  ctx.moveTo(-100, canvas.height);
+  ctx.lineTo(200, canvas.height - 180);
+  ctx.lineTo(500, canvas.height);
+  ctx.closePath();
+  ctx.fill();
+
+  ctx.beginPath();
+  ctx.moveTo(300, canvas.height);
+  ctx.lineTo(650, canvas.height - 140);
+  ctx.lineTo(980, canvas.height);
+  ctx.closePath();
+  ctx.fillStyle = '#4a8fb8';
+  ctx.fill();
+
+  // clouds
+  ctx.fillStyle = 'rgba(255, 255, 255, 0.85)';
+  drawCloud(140, 120);
+  drawCloud(520, 80);
+}
+
+function drawCloud(x, y) {
+  ctx.beginPath();
+  ctx.ellipse(x, y, 55, 24, 0, 0, Math.PI * 2);
+  ctx.ellipse(x + 40, y + 5, 45, 20, 0, 0, Math.PI * 2);
+  ctx.ellipse(x - 40, y + 5, 45, 20, 0, 0, Math.PI * 2);
+  ctx.fill();
+}
+
+function drawTiles() {
+  for (let row = 0; row < map.length; row += 1) {
+    for (let col = 0; col < map[row].length; col += 1) {
+      if (map[row][col] === 1) {
+        const x = col * tileSize;
+        const y = row * tileSize;
+        drawTile(x, y);
+      }
+    }
+  }
+}
+
+function drawTile(x, y) {
+  ctx.fillStyle = '#5f3d24';
+  ctx.fillRect(x, y + tileSize - 18, tileSize, 18);
+  ctx.fillStyle = '#7ac74f';
+  ctx.fillRect(x, y, tileSize, tileSize - 18);
+
+  ctx.fillStyle = 'rgba(255, 255, 255, 0.15)';
+  ctx.fillRect(x, y, tileSize, 6);
+}
+
+function drawPlayer() {
+  ctx.fillStyle = '#111';
+  ctx.fillRect(player.x, player.y, player.width, player.height);
+
+  ctx.fillStyle = '#fff';
+  ctx.fillRect(player.x + player.width - 10, player.y + 12, 6, 6);
+}
+
+function gameLoop() {
+  updatePlayer();
+  drawBackground();
+  drawTiles();
+  drawPlayer();
+  requestAnimationFrame(gameLoop);
+}
+
+document.addEventListener('keydown', (event) => {
+  pressedKeys.add(event.code);
+  if ((event.code === 'Space' || event.code === 'ArrowUp') && player.onGround) {
+    player.vy = player.jumpForce;
+    player.onGround = false;
+  }
+});
+
+document.addEventListener('keyup', (event) => {
+  pressedKeys.delete(event.code);
+});
+
+requestAnimationFrame(gameLoop);
+


### PR DESCRIPTION
## Summary
- create a retro-styled menu page with a central play button that routes to the scenario
- build a scenario page with a static tile map, HUD hearts, and responsive layout styling
- implement basic player movement, jumping, and background rendering on a canvas

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68f4a7ac78d0832a9a30b121a61b1578