### PR TITLE
Add shared audio mute toggle control

### DIFF
--- a/helper/audioController.js
+++ b/helper/audioController.js
@@ -1,0 +1,43 @@
+const MUTED_ICON = "🔇";
+const UNMUTED_ICON = "🔊";
+
+function updateButtonState(toggleButton, isMuted) {
+  if (!toggleButton) {
+    return;
+  }
+
+  toggleButton.dataset.muted = isMuted ? "true" : "false";
+  toggleButton.setAttribute("aria-pressed", isMuted ? "true" : "false");
+  toggleButton.setAttribute(
+    "aria-label",
+    isMuted ? "Attiva l'audio" : "Disattiva l'audio"
+  );
+  toggleButton.title = isMuted ? "Riattiva musica" : "Disattiva musica";
+  toggleButton.textContent = isMuted ? MUTED_ICON : UNMUTED_ICON;
+}
+
+export function setupAudioToggle({
+  audioElement,
+  toggleButton,
+  storageKey = "retro-arcade-muted",
+} = {}) {
+  if (!audioElement || !toggleButton) {
+    return;
+  }
+
+  const storedValue = localStorage.getItem(storageKey);
+  const initialMuted = storedValue === "true";
+
+  function applyState(muted) {
+    audioElement.muted = muted;
+    updateButtonState(toggleButton, muted);
+    localStorage.setItem(storageKey, muted ? "true" : "false");
+  }
+
+  applyState(initialMuted);
+
+  toggleButton.addEventListener("click", () => {
+    const nextState = !audioElement.muted;
+    applyState(nextState);
+  });
+}

--- a/menu/menu.css
+++ b/menu/menu.css
@@ -17,11 +17,38 @@ body {
   align-items: center;
   justify-content: center;
   text-align: center;
+  position: relative;
   background-color: #050813;
   background-image: linear-gradient(135deg, rgba(12, 17, 46, 0.9), rgba(22, 8, 64, 0.9)), var(--bg-pattern),
     url('https://images.unsplash.com/photo-1582719478248-4b8b5b8b5b8b?auto=format&fit=crop&w=1600&q=80');
   background-size: cover;
   background-position: center;
+}
+
+.audio-toggle-button {
+  position: absolute;
+  top: 1.25rem;
+  right: 1.5rem;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 50%;
+  border: 3px solid rgba(255, 255, 255, 0.7);
+  background: rgba(5, 8, 19, 0.75);
+  color: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.35rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.audio-toggle-button:hover,
+.audio-toggle-button:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 18px rgba(0, 0, 0, 0.35);
+  outline: none;
+  background: rgba(255, 77, 246, 0.85);
 }
 
 .menu-panel {

--- a/menu/menu.html
+++ b/menu/menu.html
@@ -7,14 +7,21 @@
     <link rel="stylesheet" href="menu.css" />
   </head>
   <body>
+    <button
+      id="musicToggle"
+      class="audio-toggle-button"
+      type="button"
+      aria-label="Disattiva l'audio"
+      aria-pressed="false"
+    ></button>
     <div class="menu-panel">
       <h1>Retro Arcade</h1>
       <button id="playButton" class="play-button">Play</button>
     </div>
-    <script src="menu.js"></script>
     <audio id="bg_music" class="audio" autoplay controls loop style="display: none;">
     <source src="../assets/musics/menu.mp3" type="audio/mp3" />
         Your browser does not support the audio element.
     </audio>
+    <script type="module" src="menu.js"></script>
   </body>
 </html>

--- a/menu/menu.js
+++ b/menu/menu.js
@@ -1,7 +1,13 @@
-document.addEventListener('DOMContentLoaded', () => {
-  const playButton = document.getElementById('playButton');
+import { setupAudioToggle } from "../helper/audioController.js";
 
-  playButton.addEventListener('click', () => {
-    window.location.href = '../scenario/scenario.html';
+document.addEventListener("DOMContentLoaded", () => {
+  const playButton = document.getElementById("playButton");
+
+  playButton.addEventListener("click", () => {
+    window.location.href = "../scenario/scenario.html";
   });
+
+  const audioElement = document.getElementById("bg_music");
+  const toggleButton = document.getElementById("musicToggle");
+  setupAudioToggle({ audioElement, toggleButton });
 });

--- a/scenario/scenario.css
+++ b/scenario/scenario.css
@@ -27,6 +27,33 @@ body {
   padding: 0;
 }
 
+.audio-toggle-button {
+  position: absolute;
+  top: 1rem;
+  right: 1.5rem;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 50%;
+  border: 3px solid rgba(255, 255, 255, 0.8);
+  background: rgba(10, 16, 33, 0.8);
+  color: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.35rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  z-index: 3;
+}
+
+.audio-toggle-button:hover,
+.audio-toggle-button:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 18px rgba(0, 0, 0, 0.35);
+  outline: none;
+  background: rgba(111, 183, 255, 0.85);
+}
+
 
 .hud {
   position: absolute;

--- a/scenario/scenario.html
+++ b/scenario/scenario.html
@@ -8,6 +8,13 @@
   </head>
   <body>
     <div class="game-wrapper">
+      <button
+        id="musicToggle"
+        class="audio-toggle-button"
+        type="button"
+        aria-label="Disattiva l'audio"
+        aria-pressed="false"
+      ></button>
       <header class="hud">
         <div class="lives" aria-label="Vite">
           <span class="heart" aria-hidden="true">❤</span>
@@ -19,10 +26,10 @@
         <canvas id="gameCanvas" aria-label="Scenario di gioco"></canvas>
       </main>
     </div>
-    <script type="module" src="scenario.js"></script>
     <audio id="bg_music" class="audio" autoplay controls loop style="display: none;">
     <source src="../assets/musics/scenario.mp3" type="audio/mp3" />
         Your browser does not support the audio element.
     </audio>
+    <script type="module" src="scenario.js"></script>
   </body>
 </html>

--- a/scenario/scenario.js
+++ b/scenario/scenario.js
@@ -1,8 +1,13 @@
+import { setupAudioToggle } from "../helper/audioController.js";
 import { generateMap } from "./helper/map.js";
 import { PlayerController } from "./helper/player.js";
 
 const canvas = document.getElementById("gameCanvas");
 const ctx = canvas.getContext("2d");
+
+const audioElement = document.getElementById("bg_music");
+const toggleButton = document.getElementById("musicToggle");
+setupAudioToggle({ audioElement, toggleButton });
 
 function resizeCanvas() {
     canvas.width = window.innerWidth;


### PR DESCRIPTION
## Summary
- add a reusable audio toggle helper that remembers the mute state
- show a mute/unmute button in the menu and scenario and connect it to the helper
- align styles so the control appears in the top-right corner of each screen

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f4c7aa9960832a809262dea7d5f3ef