### PR TITLE
Add enemy system with ranged and melee threats

### DIFF
--- a/scenario/constants.json
+++ b/scenario/constants.json
@@ -26,7 +26,15 @@
     "EYE_SIZE": 6,
     "BODY_COLOR": "#111111",
     "EYE_COLOR": "#ffffff",
-    "SPAWN_HORIZONTAL_DIVISOR": 2
+    "SPAWN_HORIZONTAL_DIVISOR": 2,
+    "MAX_LIVES": 3,
+    "INVINCIBILITY_WINDOW_MS": 1000
+  },
+  "PLAYER_BULLET": {
+    "SPEED": 560,
+    "RADIUS": 6,
+    "COLOR": "#ffe27a",
+    "COOLDOWN_MS": 250
   },
   "MAP": {
     "TOP_MARGIN": 2,
@@ -70,6 +78,7 @@
       "ArrowLeft",
       "ArrowRight",
       "ArrowUp",
+      "ArrowDown",
       "Space",
       "KeyA",
       "KeyD",
@@ -77,18 +86,45 @@
     ],
     "JUMP_KEYS": [
       "Space",
-      "ArrowUp",
       "KeyW"
     ],
     "MOVE_LEFT_KEYS": [
-      "ArrowLeft",
       "KeyA"
     ],
     "MOVE_RIGHT_KEYS": [
-      "ArrowRight",
       "KeyD"
+    ],
+    "SHOOT_KEYS": [
+      "ArrowUp",
+      "ArrowDown",
+      "ArrowLeft",
+      "ArrowRight"
     ],
     "EXIT_KEY": "Escape",
     "EXIT_DESTINATION": "../menu/menu.html"
+  },
+  "ENEMIES": {
+    "SPAWN_INTERVAL_MS": 10000,
+    "GROUP_SIZE": {
+      "MIN": 2,
+      "MAX": 3
+    },
+    "SPAWN_DESCENT_SPEED": 120,
+    "TRIANGLE": {
+      "WIDTH": 48,
+      "HEIGHT": 48,
+      "COLOR": "#f06b6b",
+      "MOVE_SPEED": 140,
+      "VERTICAL_ADJUST_SPEED": 110,
+      "FIRE_COOLDOWN_MS": 1800,
+      "BULLET_SPEED": 420,
+      "BULLET_COLOR": "#ff9f43",
+      "BULLET_RADIUS": 6
+    },
+    "SQUARE": {
+      "SIZE": 40,
+      "COLOR": "#5d9bff",
+      "SPEED": 180
+    }
   }
 }

--- a/scenario/enemies/square.js
+++ b/scenario/enemies/square.js
@@ -1,0 +1,73 @@
+export class SquareEnemy {
+    constructor(constants, canvas) {
+        this.constants = constants.ENEMIES.SQUARE;
+        this.globalConstants = constants.ENEMIES;
+        this.size = this.constants.SIZE;
+        this.position = {
+            x: Math.random() * Math.max(1, canvas.width - this.size),
+            y: -this.size,
+        };
+        const minTarget = this.size * 1.1;
+        const maxTarget = Math.min(canvas.height * 0.45, minTarget + this.size * 2.5);
+        const availableRange = Math.max(this.size * 0.5, maxTarget - minTarget);
+        this.targetY = Math.min(
+            canvas.height - this.size,
+            minTarget + Math.random() * availableRange
+        );
+        this.isSpawning = true;
+        this.active = true;
+    }
+
+    update(deltaTime, playerBounds, canvas) {
+        if (!this.active) {
+            return;
+        }
+
+        if (this.isSpawning) {
+            this.position.y += this.globalConstants.SPAWN_DESCENT_SPEED * deltaTime;
+            if (this.position.y >= this.targetY) {
+                this.position.y = this.targetY;
+                this.isSpawning = false;
+            }
+            return;
+        }
+
+        const playerCenterX = playerBounds.x + playerBounds.width / 2;
+        const playerCenterY = playerBounds.y + playerBounds.height / 2;
+        const enemyCenterX = this.position.x + this.size / 2;
+        const enemyCenterY = this.position.y + this.size / 2;
+
+        const dx = playerCenterX - enemyCenterX;
+        const dy = playerCenterY - enemyCenterY;
+        const distance = Math.hypot(dx, dy) || 1;
+        const velocityX = (dx / distance) * this.constants.SPEED * deltaTime;
+        const velocityY = (dy / distance) * this.constants.SPEED * deltaTime;
+
+        this.position.x += velocityX;
+        this.position.y += velocityY;
+
+        this.position.x = Math.max(0, Math.min(canvas.width - this.size, this.position.x));
+        this.position.y = Math.max(0, Math.min(canvas.height - this.size, this.position.y));
+    }
+
+    draw(ctx) {
+        if (!this.active) {
+            return;
+        }
+        ctx.fillStyle = this.constants.COLOR;
+        ctx.fillRect(this.position.x, this.position.y, this.size, this.size);
+    }
+
+    getBounds() {
+        return {
+            x: this.position.x,
+            y: this.position.y,
+            width: this.size,
+            height: this.size,
+        };
+    }
+
+    takeHit() {
+        this.active = false;
+    }
+}

--- a/scenario/enemies/triangle.js
+++ b/scenario/enemies/triangle.js
@@ -1,0 +1,140 @@
+import { Bullet } from "../helper/bullet.js";
+
+export class TriangleEnemy {
+    constructor(constants, canvas) {
+        this.constants = constants.ENEMIES.TRIANGLE;
+        this.globalConstants = constants.ENEMIES;
+        this.width = this.constants.WIDTH;
+        this.height = this.constants.HEIGHT;
+        this.position = {
+            x: Math.random() * Math.max(1, canvas.width - this.width),
+            y: -this.height,
+        };
+        const minTarget = this.height * 1.2;
+        const maxTarget = Math.min(
+            canvas.height * 0.35,
+            minTarget + this.height * 2.5
+        );
+        const availableRange = Math.max(this.height * 0.5, maxTarget - minTarget);
+        this.targetY = Math.min(
+            canvas.height - this.height,
+            minTarget + Math.random() * availableRange
+        );
+        this.isSpawning = true;
+        this.facing = 1;
+        this.lastShotAt = 0;
+        this.active = true;
+    }
+
+    update(deltaTime, playerBounds, timestamp, canvas) {
+        if (!this.active) {
+            return null;
+        }
+
+        if (this.isSpawning) {
+            this.position.y += this.globalConstants.SPAWN_DESCENT_SPEED * deltaTime;
+            if (this.position.y >= this.targetY) {
+                this.position.y = this.targetY;
+                this.isSpawning = false;
+            }
+            return null;
+        }
+
+        const playerCenterX = playerBounds.x + playerBounds.width / 2;
+        const playerCenterY = playerBounds.y + playerBounds.height / 2;
+        const enemyCenterX = this.position.x + this.width / 2;
+        const enemyCenterY = this.position.y + this.height / 2;
+
+        if (playerCenterX > enemyCenterX + 4) {
+            this.position.x += this.constants.MOVE_SPEED * deltaTime;
+            this.facing = 1;
+        } else if (playerCenterX < enemyCenterX - 4) {
+            this.position.x -= this.constants.MOVE_SPEED * deltaTime;
+            this.facing = -1;
+        }
+
+        if (playerCenterY > enemyCenterY + 6) {
+            this.position.y += this.constants.VERTICAL_ADJUST_SPEED * deltaTime;
+        } else if (playerCenterY < enemyCenterY - 6) {
+            this.position.y -= this.constants.VERTICAL_ADJUST_SPEED * deltaTime;
+        }
+
+        this.position.x = Math.max(
+            0,
+            Math.min(canvas.width - this.width, this.position.x)
+        );
+        this.position.y = Math.max(
+            0,
+            Math.min(canvas.height - this.height, this.position.y)
+        );
+
+        const sameLayer = Math.abs(playerCenterY - (this.position.y + this.height / 2)) < this.height / 2;
+        if (
+            sameLayer &&
+            timestamp - this.lastShotAt >= this.constants.FIRE_COOLDOWN_MS
+        ) {
+            this.lastShotAt = timestamp;
+            return this.fireBullet();
+        }
+
+        return null;
+    }
+
+    fireBullet() {
+        const originX =
+            this.position.x +
+            (this.facing > 0
+                ? this.width + this.constants.BULLET_RADIUS
+                : -this.constants.BULLET_RADIUS);
+        const originY = this.position.y + this.height / 2;
+
+        return new Bullet({
+            x: originX,
+            y: originY,
+            direction: { x: this.facing, y: 0 },
+            speed: this.constants.BULLET_SPEED,
+            radius: this.constants.BULLET_RADIUS,
+            color: this.constants.BULLET_COLOR,
+            fromEnemy: true,
+        });
+    }
+
+    draw(ctx) {
+        if (!this.active) {
+            return;
+        }
+
+        ctx.fillStyle = this.constants.COLOR;
+        ctx.beginPath();
+        if (this.facing >= 0) {
+            ctx.moveTo(this.position.x, this.position.y);
+            ctx.lineTo(this.position.x, this.position.y + this.height);
+            ctx.lineTo(
+                this.position.x + this.width,
+                this.position.y + this.height / 2
+            );
+        } else {
+            ctx.moveTo(this.position.x + this.width, this.position.y);
+            ctx.lineTo(
+                this.position.x + this.width,
+                this.position.y + this.height
+            );
+            ctx.lineTo(this.position.x, this.position.y + this.height / 2);
+        }
+        ctx.closePath();
+        ctx.fill();
+    }
+
+    getBounds() {
+        return {
+            x: this.position.x,
+            y: this.position.y,
+            width: this.width,
+            height: this.height,
+        };
+    }
+
+    takeHit() {
+        this.active = false;
+    }
+}

--- a/scenario/helper/bullet.js
+++ b/scenario/helper/bullet.js
@@ -1,0 +1,51 @@
+export class Bullet {
+    constructor({ x, y, direction, speed, radius, color, fromEnemy = false }) {
+        const magnitude = Math.hypot(direction.x, direction.y) || 1;
+        this.position = { x, y };
+        this.velocity = {
+            x: (direction.x / magnitude) * speed,
+            y: (direction.y / magnitude) * speed,
+        };
+        this.radius = radius;
+        this.color = color;
+        this.fromEnemy = fromEnemy;
+        this.active = true;
+    }
+
+    update(deltaTime, canvas) {
+        const dt = deltaTime || 0;
+        this.position.x += this.velocity.x * dt;
+        this.position.y += this.velocity.y * dt;
+
+        if (this.isOffscreen(canvas)) {
+            this.active = false;
+        }
+    }
+
+    draw(ctx) {
+        if (!this.active) {
+            return;
+        }
+        ctx.fillStyle = this.color;
+        ctx.beginPath();
+        ctx.arc(this.position.x, this.position.y, this.radius, 0, Math.PI * 2);
+        ctx.fill();
+    }
+
+    isOffscreen(canvas) {
+        return (
+            this.position.x < -this.radius ||
+            this.position.x > canvas.width + this.radius ||
+            this.position.y < -this.radius ||
+            this.position.y > canvas.height + this.radius
+        );
+    }
+
+    intersectsRect({ x, y, width, height }) {
+        const closestX = Math.max(x, Math.min(this.position.x, x + width));
+        const closestY = Math.max(y, Math.min(this.position.y, y + height));
+        const dx = this.position.x - closestX;
+        const dy = this.position.y - closestY;
+        return dx * dx + dy * dy <= this.radius * this.radius;
+    }
+}

--- a/scenario/helper/player.js
+++ b/scenario/helper/player.js
@@ -253,4 +253,20 @@ export class PlayerController {
             this.constants.PLAYER.EYE_SIZE
         );
     }
+
+    getBounds() {
+        return {
+            x: this.state.x,
+            y: this.state.y,
+            width: this.state.width,
+            height: this.state.height,
+        };
+    }
+
+    getCenter() {
+        return {
+            x: this.state.x + this.state.width / 2,
+            y: this.state.y + this.state.height / 2,
+        };
+    }
 }

--- a/scenario/scenario.css
+++ b/scenario/scenario.css
@@ -72,6 +72,12 @@ body {
   transform-origin: center;
 }
 
+.lives .heart.lost {
+  opacity: 0.25;
+  filter: grayscale(1);
+  animation: none;
+}
+
 .lives .heart:nth-child(2) { animation-delay: .15s; }
 .lives .heart:nth-child(3) { animation-delay: .30s; }
 

--- a/scenario/scenario.js
+++ b/scenario/scenario.js
@@ -1,9 +1,13 @@
 import { setupAudioToggle } from "../helper/audioController.js";
 import { generateMap } from "./helper/map.js";
 import { PlayerController } from "./helper/player.js";
+import { Bullet } from "./helper/bullet.js";
+import { TriangleEnemy } from "./enemies/triangle.js";
+import { SquareEnemy } from "./enemies/square.js";
 
 const canvas = document.getElementById("gameCanvas");
 const ctx = canvas.getContext("2d");
+const heartsElements = Array.from(document.querySelectorAll(".heart"));
 
 const audioElement = document.getElementById("bg_music");
 const toggleButton = document.getElementById("musicToggle");
@@ -29,30 +33,31 @@ function createKeySet(values) {
     return new Set(values);
 }
 
-
 function drawBackground(ctxInstance, backgroundImage) {
-  ctxInstance.clearRect(0, 0, canvas.width, canvas.height);
+    ctxInstance.clearRect(0, 0, canvas.width, canvas.height);
     if (!backgroundImage.complete) {
-    return;}
-  const canvasAspectRatio = canvas.width / canvas.height;
-  const imageAspectRatio = backgroundImage.width / backgroundImage.height;
+        return;
+    }
 
-  let drawWidth;
-  let drawHeight;
-  let offsetX = 0;
-  let offsetY = 0;
+    const canvasAspectRatio = canvas.width / canvas.height;
+    const imageAspectRatio = backgroundImage.width / backgroundImage.height;
 
-  if (canvasAspectRatio > imageAspectRatio) {
-    drawWidth = canvas.width;
-    drawHeight = canvas.width / imageAspectRatio;
-    offsetY = (canvas.height - drawHeight) / 2;
-  } else {
-    drawHeight = canvas.height;
-    drawWidth = canvas.height * imageAspectRatio;
-    offsetX = (canvas.width - drawWidth) / 2;
-  }
+    let drawWidth;
+    let drawHeight;
+    let offsetX = 0;
+    let offsetY = 0;
 
-  ctxInstance.drawImage(backgroundImage, offsetX, offsetY, drawWidth, drawHeight);
+    if (canvasAspectRatio > imageAspectRatio) {
+        drawWidth = canvas.width;
+        drawHeight = canvas.width / imageAspectRatio;
+        offsetY = (canvas.height - drawHeight) / 2;
+    } else {
+        drawHeight = canvas.height;
+        drawWidth = canvas.height * imageAspectRatio;
+        offsetX = (canvas.width - drawWidth) / 2;
+    }
+
+    ctxInstance.drawImage(backgroundImage, offsetX, offsetY, drawWidth, drawHeight);
 }
 
 function drawTile(ctxInstance, x, y, tileSize, constants) {
@@ -68,14 +73,13 @@ function drawTile(ctxInstance, x, y, tileSize, constants) {
 }
 
 function loadImage(src) {
-  return new Promise((resolve, reject) => {
-    const image = new Image();
-    image.onload = () => resolve(image);
-    image.onerror = () => reject(new Error(`Unable to load image: ${src}`));
-    image.src = src;
-  });
+    return new Promise((resolve, reject) => {
+        const image = new Image();
+        image.onload = () => resolve(image);
+        image.onerror = () => reject(new Error(`Unable to load image: ${src}`));
+        image.src = src;
+    });
 }
-
 
 function drawTiles(mapData, constants) {
     const tileSize = constants.TILE_SIZE;
@@ -92,9 +96,33 @@ function drawTiles(mapData, constants) {
     }
 }
 
+function rectanglesIntersect(a, b) {
+    return (
+        a.x < b.x + b.width &&
+        a.x + a.width > b.x &&
+        a.y < b.y + b.height &&
+        a.y + a.height > b.y
+    );
+}
+
+function drawGameOverOverlay() {
+    ctx.save();
+    ctx.fillStyle = "rgba(0, 0, 0, 0.65)";
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.fillStyle = "#ffffff";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    const fontSize = Math.max(24, Math.min(canvas.width, canvas.height) * 0.06);
+    ctx.font = `bold ${fontSize}px 'Press Start 2P', 'Courier New', monospace`;
+    ctx.fillText("GAME OVER", canvas.width / 2, canvas.height / 2);
+    ctx.restore();
+}
+
 async function initializeGame() {
     const constants = await loadConstants();
-    const backgroundImage = await loadImage(constants.BACKGROUND.BACKGROUND_IMAGE_SRC);
+    const backgroundImage = await loadImage(
+        constants.BACKGROUND.BACKGROUND_IMAGE_SRC
+    );
 
     const mapData = generateMap(canvas, constants);
     const playerController = new PlayerController(constants, mapData, canvas);
@@ -107,11 +135,231 @@ async function initializeGame() {
     const exitKey = constants.INPUT.EXIT_KEY;
     const exitDestination = constants.INPUT.EXIT_DESTINATION;
 
-    function gameLoop() {
-        playerController.update(pressedKeys);
+    let lastFrameTime = performance.now();
+    let lastSpawnTimestamp = lastFrameTime;
+    let lastPlayerShot = 0;
+    let lastDamageAt = -Infinity;
+    let playerLives = constants.PLAYER.MAX_LIVES;
+    let isGameOver = false;
+    let redirectHandle;
+
+    let enemies = [];
+    let playerBullets = [];
+    let enemyBullets = [];
+
+    updateLivesDisplay(playerLives);
+
+    function updateLivesDisplay(lives) {
+        heartsElements.forEach((heart, index) => {
+            heart.classList.toggle("lost", index >= lives);
+        });
+        const livesContainer = document.querySelector(".lives");
+        if (livesContainer) {
+            livesContainer.setAttribute("aria-label", `Vite rimaste: ${lives}`);
+        }
+    }
+
+    function damagePlayer(timestamp) {
+        if (isGameOver) {
+            return;
+        }
+        if (timestamp - lastDamageAt < constants.PLAYER.INVINCIBILITY_WINDOW_MS) {
+            return;
+        }
+        lastDamageAt = timestamp;
+        playerLives = Math.max(0, playerLives - 1);
+        updateLivesDisplay(playerLives);
+        if (playerLives <= 0) {
+            triggerGameOver();
+        }
+    }
+
+    function triggerGameOver() {
+        if (isGameOver) {
+            return;
+        }
+        isGameOver = true;
+        pressedKeys.clear();
+        redirectHandle = window.setTimeout(() => {
+            window.location.href = exitDestination;
+        }, 2500);
+    }
+
+    function spawnEnemyGroup() {
+        const { MIN, MAX } = constants.ENEMIES.GROUP_SIZE;
+        const totalEnemies = Math.floor(Math.random() * (MAX - MIN + 1)) + MIN;
+        const spawned = [];
+
+        if (totalEnemies >= 1) {
+            spawned.push(new TriangleEnemy(constants, canvas));
+        }
+        if (totalEnemies >= 2) {
+            spawned.push(new SquareEnemy(constants, canvas));
+        }
+        while (spawned.length < totalEnemies) {
+            const enemyClass = Math.random() > 0.5 ? TriangleEnemy : SquareEnemy;
+            spawned.push(new enemyClass(constants, canvas));
+        }
+
+        enemies.push(...spawned);
+    }
+
+    function getShootingDirectionFromKeys() {
+        let directionX = 0;
+        let directionY = 0;
+        let hasInput = false;
+
+        constants.INPUT.SHOOT_KEYS.forEach((code) => {
+            if (!pressedKeys.has(code)) {
+                return;
+            }
+            hasInput = true;
+            switch (code) {
+                case "ArrowUp":
+                    directionY -= 1;
+                    break;
+                case "ArrowDown":
+                    directionY += 1;
+                    break;
+                case "ArrowLeft":
+                    directionX -= 1;
+                    break;
+                case "ArrowRight":
+                    directionX += 1;
+                    break;
+                default:
+                    break;
+            }
+        });
+
+        if (!hasInput) {
+            return null;
+        }
+
+        if (directionX === 0 && directionY === 0) {
+            return null;
+        }
+
+        return { x: directionX, y: directionY };
+    }
+
+    function handlePlayerShooting(timestamp) {
+        const direction = getShootingDirectionFromKeys();
+        if (!direction) {
+            return;
+        }
+        if (timestamp - lastPlayerShot < constants.PLAYER_BULLET.COOLDOWN_MS) {
+            return;
+        }
+        lastPlayerShot = timestamp;
+        const center = playerController.getCenter();
+        playerBullets.push(
+            new Bullet({
+                x: center.x,
+                y: center.y,
+                direction,
+                speed: constants.PLAYER_BULLET.SPEED,
+                radius: constants.PLAYER_BULLET.RADIUS,
+                color: constants.PLAYER_BULLET.COLOR,
+            })
+        );
+    }
+
+    function updateEnemies(deltaTime, timestamp, playerBounds) {
+        enemies.forEach((enemy) => {
+            if (enemy instanceof TriangleEnemy) {
+                const bullet = enemy.update(deltaTime, playerBounds, timestamp, canvas);
+                if (bullet) {
+                    enemyBullets.push(bullet);
+                }
+            } else {
+                enemy.update(deltaTime, playerBounds, canvas);
+            }
+        });
+        enemies = enemies.filter((enemy) => enemy.active);
+    }
+
+    function updatePlayerBullets(deltaTime) {
+        playerBullets.forEach((bullet) => bullet.update(deltaTime, canvas));
+        playerBullets.forEach((bullet) => {
+            if (!bullet.active) {
+                return;
+            }
+            for (const enemy of enemies) {
+                if (!enemy.active) {
+                    continue;
+                }
+                if (bullet.intersectsRect(enemy.getBounds())) {
+                    bullet.active = false;
+                    enemy.takeHit();
+                    break;
+                }
+            }
+        });
+        enemies = enemies.filter((enemy) => enemy.active);
+        playerBullets = playerBullets.filter((bullet) => bullet.active);
+    }
+
+    function updateEnemyBullets(deltaTime, timestamp, playerBounds) {
+        enemyBullets.forEach((bullet) => bullet.update(deltaTime, canvas));
+        enemyBullets.forEach((bullet) => {
+            if (!bullet.active) {
+                return;
+            }
+            if (bullet.intersectsRect(playerBounds)) {
+                bullet.active = false;
+                damagePlayer(timestamp);
+            }
+        });
+        enemyBullets = enemyBullets.filter((bullet) => bullet.active);
+    }
+
+    function handleEnemyCollisions(timestamp, playerBounds) {
+        enemies.forEach((enemy) => {
+            if (!(enemy instanceof SquareEnemy)) {
+                return;
+            }
+            if (enemy.isSpawning) {
+                return;
+            }
+            if (rectanglesIntersect(enemy.getBounds(), playerBounds)) {
+                damagePlayer(timestamp);
+            }
+        });
+    }
+
+    function gameLoop(timestamp) {
+        const deltaTime = Math.min((timestamp - lastFrameTime) / 1000, 0.05);
+        lastFrameTime = timestamp;
+
+        if (!isGameOver) {
+            playerController.update(pressedKeys);
+            handlePlayerShooting(timestamp);
+
+            if (timestamp - lastSpawnTimestamp >= constants.ENEMIES.SPAWN_INTERVAL_MS) {
+                spawnEnemyGroup();
+                lastSpawnTimestamp = timestamp;
+            }
+
+            const playerBounds = playerController.getBounds();
+            updateEnemies(deltaTime, timestamp, playerBounds);
+            updatePlayerBullets(deltaTime);
+            updateEnemyBullets(deltaTime, timestamp, playerBounds);
+            handleEnemyCollisions(timestamp, playerBounds);
+        }
+
         drawBackground(ctx, backgroundImage);
         drawTiles(mapData, constants);
+
+        enemies.forEach((enemy) => enemy.draw(ctx));
+        enemyBullets.forEach((bullet) => bullet.draw(ctx));
+        playerBullets.forEach((bullet) => bullet.draw(ctx));
         playerController.draw(ctx);
+
+        if (isGameOver) {
+            drawGameOverOverlay();
+        }
+
         requestAnimationFrame(gameLoop);
     }
 
@@ -127,7 +375,7 @@ async function initializeGame() {
             return;
         }
 
-        if (jumpKeys.has(event.code)) {
+        if (!isGameOver && jumpKeys.has(event.code)) {
             playerController.queueJump();
         }
     });
@@ -136,7 +384,17 @@ async function initializeGame() {
         pressedKeys.delete(event.code);
     });
 
-    requestAnimationFrame(gameLoop);
+    requestAnimationFrame((timestamp) => {
+        lastFrameTime = timestamp;
+        lastSpawnTimestamp = timestamp;
+        gameLoop(timestamp);
+    });
+
+    window.addEventListener("beforeunload", () => {
+        if (redirectHandle) {
+            window.clearTimeout(redirectHandle);
+        }
+    });
 }
 
 initializeGame().catch((error) => {


### PR DESCRIPTION
## Summary
- add reusable bullet helper and expose player bounds for combat logic
- create triangle and square enemy types with spawning, chasing, and shooting behaviors
- overhaul scenario loop to handle enemy waves, player shooting, heart tracking, and game over overlay

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f4fb3f83d0832a8c445d1d0d5518f7