### PR TITLE
Improve enemy platforming and menu flow

### DIFF
--- a/scenario/constants.json
+++ b/scenario/constants.json
@@ -124,7 +124,13 @@
     "SQUARE": {
       "SIZE": 40,
       "COLOR": "#5d9bff",
-      "SPEED": 180
+      "MOVE_ACCELERATION": 0.65,
+      "MAX_SPEED": 3.4,
+      "DECELERATION_FACTOR": 0.8,
+      "MIN_SPEED_THRESHOLD": 0.04,
+      "JUMP_FORCE": -16,
+      "MAX_FALL_SPEED": 14,
+      "JUMP_COOLDOWN_MS": 900
     }
   }
 }

--- a/scenario/enemies/square.js
+++ b/scenario/enemies/square.js
@@ -1,53 +1,249 @@
+import { checkCollision, isSolidTile } from "../helper/map.js";
+
 export class SquareEnemy {
-    constructor(constants, canvas) {
+    constructor(constants, canvas, mapData) {
         this.constants = constants.ENEMIES.SQUARE;
-        this.globalConstants = constants.ENEMIES;
+        this.fullConstants = constants;
+        this.map = mapData.grid;
+        this.tileSize = constants.TILE_SIZE;
+        this.mapOffsetY = mapData.verticalOffset;
         this.size = this.constants.SIZE;
-        this.position = {
-            x: Math.random() * Math.max(1, canvas.width - this.size),
-            y: -this.size,
-        };
-        const minTarget = this.size * 1.1;
-        const maxTarget = Math.min(canvas.height * 0.45, minTarget + this.size * 2.5);
-        const availableRange = Math.max(this.size * 0.5, maxTarget - minTarget);
-        this.targetY = Math.min(
-            canvas.height - this.size,
-            minTarget + Math.random() * availableRange
+        this.collisionOffset = constants.PLAYER.COLLISION_OFFSET;
+
+        const platforms = mapData.platforms.length > 0 ? mapData.platforms : [
+            {
+                row: mapData.floorRow,
+                colStart: 0,
+                colEnd: mapData.cols - 1,
+            },
+        ];
+        const chosenPlatform =
+            platforms[Math.floor(Math.random() * platforms.length)] || platforms[0];
+        const minX = chosenPlatform.colStart * this.tileSize;
+        const maxX =
+            (chosenPlatform.colEnd + 1) * this.tileSize - this.size - this.collisionOffset;
+        const spawnX = Math.min(
+            Math.max(0, maxX),
+            Math.max(
+                Math.max(0, minX),
+                minX + Math.random() * Math.max(1, maxX - minX)
+            )
         );
-        this.isSpawning = true;
+        const spawnY =
+            this.mapOffsetY +
+            chosenPlatform.row * this.tileSize -
+            this.size -
+            this.collisionOffset;
+
+        this.state = {
+            width: this.size,
+            height: this.size,
+            x: spawnX,
+            y: spawnY,
+            vx: 0,
+            vy: 0,
+            onGround: true,
+        };
+
         this.active = true;
+        this.isSpawning = false;
+        this.lastJumpAt = -Infinity;
     }
 
-    update(deltaTime, playerBounds, canvas) {
+    update(deltaTime, playerBounds, timestamp, canvas) {
         if (!this.active) {
             return;
         }
 
-        if (this.isSpawning) {
-            this.position.y += this.globalConstants.SPAWN_DESCENT_SPEED * deltaTime;
-            if (this.position.y >= this.targetY) {
-                this.position.y = this.targetY;
-                this.isSpawning = false;
-            }
-            return;
-        }
+        const now = typeof timestamp === "number" ? timestamp : performance.now();
 
         const playerCenterX = playerBounds.x + playerBounds.width / 2;
-        const playerCenterY = playerBounds.y + playerBounds.height / 2;
-        const enemyCenterX = this.position.x + this.size / 2;
-        const enemyCenterY = this.position.y + this.size / 2;
+        const enemyCenterX = this.state.x + this.state.width / 2;
+        const horizontalDirection =
+            playerCenterX > enemyCenterX + 4
+                ? 1
+                : playerCenterX < enemyCenterX - 4
+                ? -1
+                : 0;
 
-        const dx = playerCenterX - enemyCenterX;
-        const dy = playerCenterY - enemyCenterY;
-        const distance = Math.hypot(dx, dy) || 1;
-        const velocityX = (dx / distance) * this.constants.SPEED * deltaTime;
-        const velocityY = (dy / distance) * this.constants.SPEED * deltaTime;
+        if (horizontalDirection !== 0) {
+            this.state.vx +=
+                horizontalDirection * this.constants.MOVE_ACCELERATION;
+        } else {
+            this.state.vx *= this.constants.DECELERATION_FACTOR;
+            if (Math.abs(this.state.vx) < this.constants.MIN_SPEED_THRESHOLD) {
+                this.state.vx = 0;
+            }
+        }
 
-        this.position.x += velocityX;
-        this.position.y += velocityY;
+        const maxSpeed = this.constants.MAX_SPEED;
+        this.state.vx = Math.max(Math.min(this.state.vx, maxSpeed), -maxSpeed);
 
-        this.position.x = Math.max(0, Math.min(canvas.width - this.size, this.position.x));
-        this.position.y = Math.max(0, Math.min(canvas.height - this.size, this.position.y));
+        if (
+            this.state.onGround &&
+            now - this.lastJumpAt >= this.constants.JUMP_COOLDOWN_MS &&
+            this.shouldAttemptJump(horizontalDirection, playerBounds)
+        ) {
+            this.performJump(now);
+        }
+
+        this.state.vy += this.fullConstants.GRAVITY;
+        if (this.state.vy > this.constants.MAX_FALL_SPEED) {
+            this.state.vy = this.constants.MAX_FALL_SPEED;
+        }
+
+        let nextX = this.state.x + this.state.vx;
+        let nextY = this.state.y + this.state.vy;
+
+        this.state.onGround = false;
+
+        if (this.state.vx > 0) {
+            if (
+                checkCollision(
+                    this.map,
+                    nextX,
+                    this.state.y,
+                    this.state.width,
+                    this.state.height,
+                    this.tileSize,
+                    this.mapOffsetY,
+                    this.fullConstants
+                )
+            ) {
+                nextX =
+                    Math.floor(
+                        (this.state.x + this.state.width + this.state.vx) / this.tileSize
+                    ) *
+                        this.tileSize -
+                    this.state.width -
+                    this.collisionOffset;
+                this.state.vx = 0;
+            }
+        } else if (this.state.vx < 0) {
+            if (
+                checkCollision(
+                    this.map,
+                    nextX,
+                    this.state.y,
+                    this.state.width,
+                    this.state.height,
+                    this.tileSize,
+                    this.mapOffsetY,
+                    this.fullConstants
+                )
+            ) {
+                nextX =
+                    Math.floor(this.state.x / this.tileSize) * this.tileSize +
+                    this.collisionOffset;
+                this.state.vx = 0;
+            }
+        }
+
+        if (this.state.vy > 0) {
+            if (
+                checkCollision(
+                    this.map,
+                    nextX,
+                    nextY,
+                    this.state.width,
+                    this.state.height,
+                    this.tileSize,
+                    this.mapOffsetY,
+                    this.fullConstants
+                )
+            ) {
+                nextY =
+                    Math.floor(
+                        (this.state.y +
+                            this.state.height +
+                            this.state.vy -
+                            this.mapOffsetY) /
+                            this.tileSize
+                    ) *
+                        this.tileSize +
+                    this.mapOffsetY -
+                    this.state.height -
+                    this.collisionOffset;
+                this.state.vy = 0;
+                this.state.onGround = true;
+            }
+        } else if (this.state.vy < 0) {
+            if (
+                checkCollision(
+                    this.map,
+                    nextX,
+                    nextY,
+                    this.state.width,
+                    this.state.height,
+                    this.tileSize,
+                    this.mapOffsetY,
+                    this.fullConstants
+                )
+            ) {
+                nextY =
+                    Math.floor(
+                        (this.state.y - this.mapOffsetY) / this.tileSize
+                    ) *
+                        this.tileSize +
+                    this.mapOffsetY +
+                    this.collisionOffset;
+                this.state.vy = 0;
+            }
+        }
+
+        this.state.x = Math.max(0, Math.min(nextX, canvas.width - this.state.width));
+        this.state.y = Math.min(nextY, canvas.height - this.state.height);
+
+        if (
+            this.state.y >=
+            canvas.height - this.state.height - this.collisionOffset
+        ) {
+            this.state.onGround = true;
+            this.state.vy = 0;
+        }
+
+        if (this.state.y + this.state.height + this.collisionOffset >= canvas.height) {
+            const groundCheck = this.state.y + this.state.height + this.collisionOffset;
+            if (groundCheck >= canvas.height) {
+                this.state.y =
+                    canvas.height - this.state.height - this.collisionOffset;
+            }
+        }
+    }
+
+    performJump(timestamp) {
+        this.state.vy = this.constants.JUMP_FORCE;
+        this.state.onGround = false;
+        this.lastJumpAt = timestamp;
+    }
+
+    shouldAttemptJump(direction, playerBounds) {
+        if (direction === 0) {
+            return false;
+        }
+
+        const frontX =
+            direction > 0
+                ? this.state.x + this.state.width + this.collisionOffset
+                : this.state.x - this.collisionOffset;
+        const midY = this.state.y + this.state.height / 2;
+        const footY = this.state.y + this.state.height + this.collisionOffset;
+        const gapCheckY = footY + this.tileSize * 0.25;
+
+        const obstacleAhead =
+            this.isSolidAt(frontX, midY) || this.isSolidAt(frontX, footY - 1);
+        const gapAhead = !this.isSolidAt(frontX, gapCheckY);
+        const playerHigher =
+            playerBounds.y + playerBounds.height <
+            this.state.y + this.state.height - this.tileSize * 0.5;
+
+        return obstacleAhead || gapAhead || playerHigher;
+    }
+
+    isSolidAt(x, y) {
+        const col = Math.floor(x / this.tileSize);
+        const row = Math.floor((y - this.mapOffsetY) / this.tileSize);
+        return isSolidTile(this.map, row, col, this.fullConstants);
     }
 
     draw(ctx) {
@@ -55,15 +251,20 @@ export class SquareEnemy {
             return;
         }
         ctx.fillStyle = this.constants.COLOR;
-        ctx.fillRect(this.position.x, this.position.y, this.size, this.size);
+        ctx.fillRect(
+            this.state.x,
+            this.state.y,
+            this.state.width,
+            this.state.height
+        );
     }
 
     getBounds() {
         return {
-            x: this.position.x,
-            y: this.position.y,
-            width: this.size,
-            height: this.size,
+            x: this.state.x,
+            y: this.state.y,
+            width: this.state.width,
+            height: this.state.height,
         };
     }
 

--- a/scenario/scenario.css
+++ b/scenario/scenario.css
@@ -98,6 +98,36 @@ body {
   overflow: hidden;
 }
 
+.game-over-button {
+  position: absolute;
+  left: 50%;
+  top: 52%;
+  transform: translate(-50%, -50%);
+  padding: 0.9rem 1.8rem;
+  font-size: 0.95rem;
+  background: rgba(93, 155, 255, 0.9);
+  color: #0a1021;
+  border: 3px solid rgba(255, 255, 255, 0.85);
+  border-radius: 12px;
+  cursor: pointer;
+  box-shadow: 0 12px 22px rgba(0, 0, 0, 0.35);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  z-index: 4;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.game-over-button:hover,
+.game-over-button:focus {
+  transform: translate(-50%, -50%) scale(1.04);
+  box-shadow: 0 16px 28px rgba(0, 0, 0, 0.45);
+  outline: none;
+}
+
+.game-over-button[hidden] {
+  display: none;
+}
+
 canvas {
   display: block;
   width: 100%;

--- a/scenario/scenario.html
+++ b/scenario/scenario.html
@@ -24,6 +24,14 @@
       </header>
       <main class="game-area">
         <canvas id="gameCanvas" aria-label="Scenario di gioco"></canvas>
+        <button
+          id="returnMenuButton"
+          class="game-over-button"
+          type="button"
+          hidden
+        >
+          Torna al menu
+        </button>
       </main>
     </div>
     <audio id="bg_music" class="audio" autoplay controls loop style="display: none;">


### PR DESCRIPTION
## Summary
- make square enemies spawn on solid platforms, walk, and jump using tile collisions
- stop both player and enemy bullets when they touch solid tiles
- show a persistent game over overlay with a button that returns to the menu instead of auto-redirecting

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68f4fefe2210832ab3b49a0c9ce8daf1