### PR TITLE
Add random horizontal behavior when square enemy hits vertical obstacles

### DIFF
--- a/scenario/enemies/square.js
+++ b/scenario/enemies/square.js
@@ -221,6 +221,7 @@ export class SquareEnemy {
                     this.collisionOffset;
                 this.state.vy = 0;
                 this.state.onGround = true;
+                this.chooseRandomHorizontalDirection();
             }
         } else if (this.state.vy < 0) {
             if (
@@ -243,6 +244,7 @@ export class SquareEnemy {
                     this.mapOffsetY +
                     this.collisionOffset;
                 this.state.vy = 0;
+                this.chooseRandomHorizontalDirection();
             }
         }
 
@@ -304,6 +306,16 @@ export class SquareEnemy {
         const gapAhead = !this.isSolidAt(frontX, gapCheckY);
 
         return obstacleAhead || gapAhead || playerHigher || targetAbove;
+    }
+
+    chooseRandomHorizontalDirection() {
+        const randomDirection = Math.random() < 0.5 ? -1 : 1;
+        const horizontalSpeed =
+            Math.max(
+                this.constants.MAX_SPEED * 0.6,
+                Math.abs(this.state.vx)
+            ) || this.constants.MAX_SPEED * 0.6;
+        this.state.vx = randomDirection * horizontalSpeed;
     }
 
     getCurrentWaypoint(playerBounds, timestamp) {


### PR DESCRIPTION
## Summary
- trigger a random horizontal movement direction when the square enemy collides while moving vertically
- ensure the square enemy reacts to blocked upward or downward motion by choosing a side to move toward

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f524a3467c832a825fa2b16ae50691